### PR TITLE
Nix Support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728018373,
+        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "jank-lang/clojure.test";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          pkgs.clj-kondo
+          pkgs.clojure
+          pkgs.clojure-lsp
+          pkgs.leiningen
+          pkgs.temurin-jre-bin-17
+        ];
+      };
+    });
+}


### PR DESCRIPTION
This PR adds nix files to specify which tools are required to work on this project. This can then be combined with
[nix-direnv](https://github.com/nix-community/nix-direnv) by adding test `use flake` in a .envrc file and running `direnv allow .`. This uses nix to install the deps, and hooks into direnv so those binaries are readily available. Then all devs have to do is `cd jank-lang/clojure-test` and direnv will do the heavy lifting of linking the packages into the shell env so all that's needed is to run `lein test` and it works as expected.

This approach comes with several benefits:
- All devs are working with the same version via flake.lock.
- If you use flakes across other clojure projects you can have one version of clojure on disk, but at any point specify a specific version override on a project basis.
- Don't need to install these packages on the system. For example, you don't need to pollute your system with lein, it's only installed for this project.

To get started with nix, go through https://zero-to-nix.com/.

Summary:

- Adds a flake.nix with clojure, java, clj-kondo, and clojure-lsp
- Adds the flake.lock file