### PR TITLE
Wrap bit-X NPE checks in reader conditionals

### DIFF
--- a/test/clojure/core_test/bit_and.cljc
+++ b/test/clojure/core_test/bit_and.cljc
@@ -3,8 +3,10 @@
             [clojure.core-test.number-range :as r]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-and nil 1)))
-  (t/is (thrown? NullPointerException (bit-and 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-and nil 1)))
+     :cljs (t/is (bit-and nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-and 1 nil)))
+     :cljs (t/is (bit-and 1 nil)))
 
   (t/are [ex a b] (= ex (bit-and a b))
          8 12 9

--- a/test/clojure/core_test/bit_and_not.cljc
+++ b/test/clojure/core_test/bit_and_not.cljc
@@ -3,8 +3,10 @@
             [clojure.core-test.number-range :as r]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-and-not nil 1)))
-  (t/is (thrown? NullPointerException (bit-and-not 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-and-not nil 1)))
+     :cljs (t/is (bit-and-not nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-and-not 1 nil)))
+     :cljs (t/is (bit-and-not 1 nil)))
 
   (t/are [ex a b] (= ex (bit-and-not a b))
          0 0 0

--- a/test/clojure/core_test/bit_clear.cljc
+++ b/test/clojure/core_test/bit_clear.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-clear nil 1)))
-  (t/is (thrown? NullPointerException (bit-clear 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-clear nil 1)))
+     :cljs (t/is (bit-clear nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-clear 1 nil)))
+     :cljs (t/is (bit-clear 1 nil)))
 
   (t/are [ex a b] (= ex (bit-clear a b))
          3 11 3))

--- a/test/clojure/core_test/bit_flip.cljc
+++ b/test/clojure/core_test/bit_flip.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-flip nil 1)))
-  (t/is (thrown? NullPointerException (bit-flip 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-flip nil 1)))
+     :cljs (t/is (bit-flip nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-flip 1 nil)))
+     :cljs (t/is (bit-flip 1 nil)))
 
   (t/are [ex a b] (= ex (bit-flip a b))
          2r1111 2r1011 2

--- a/test/clojure/core_test/bit_not.cljc
+++ b/test/clojure/core_test/bit_not.cljc
@@ -2,7 +2,8 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-not nil)))
+#?(:clj (t/is (thrown? NullPointerException (bit-not nil)))
+   :cljs (t/is (bit-not nil)))
 
   (t/are [ex a] (= ex (bit-not a))
          -2r1000 2r0111

--- a/test/clojure/core_test/bit_or.cljc
+++ b/test/clojure/core_test/bit_or.cljc
@@ -3,8 +3,10 @@
             [clojure.core-test.number-range :as r]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-or nil 1)))
-  (t/is (thrown? NullPointerException (bit-or 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-or nil 1)))
+     :cljs (t/is (bit-or nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-or 1 nil)))
+     :cljs (t/is (bit-or 1 nil)))
 
   (t/are [ex a b] (= ex (bit-or a b))
          2r1101 2r1100 2r1001

--- a/test/clojure/core_test/bit_set.cljc
+++ b/test/clojure/core_test/bit_set.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-set nil 1)))
-  (t/is (thrown? NullPointerException (bit-set 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-set nil 1)))
+     :cljs (t/is (bit-set nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-set 1 nil)))
+     :cljs (t/is (bit-set 1 nil)))
 
   (t/are [ex a b] (= ex (bit-set a b))
          2r1111 2r1011 2

--- a/test/clojure/core_test/bit_shift_left.cljc
+++ b/test/clojure/core_test/bit_shift_left.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-shift-left nil 1)))
-  (t/is (thrown? NullPointerException (bit-shift-left 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-shift-left nil 1)))
+     :cljs (t/is (bit-shift-left nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-shift-left 1 nil)))
+     :cljs (t/is (bit-shift-left 1 nil)))
 
   (t/are [ex a b] (= ex (bit-shift-left a b))
          1024 1 10

--- a/test/clojure/core_test/bit_shift_right.cljc
+++ b/test/clojure/core_test/bit_shift_right.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-shift-right nil 1)))
-  (t/is (thrown? NullPointerException (bit-shift-right 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-shift-right nil 1)))
+     :cljs (t/is (bit-shift-right nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-shift-right 1 nil)))
+     :cljs (t/is (bit-shift-right 1 nil)))
 
   (t/are [ex a b] (= ex (bit-shift-right a b))
          2r1101 2r1101 0

--- a/test/clojure/core_test/bit_test.cljc
+++ b/test/clojure/core_test/bit_test.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-test nil 1)))
-  (t/is (thrown? NullPointerException (bit-test 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-test nil 1)))
+     :cljs (t/is (bit-test nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-test 1 nil)))
+     :cljs (t/is (bit-test 1 nil)))
 
   (t/are [ex a b] (= ex (bit-test a b))
          true 2r1001 0

--- a/test/clojure/core_test/bit_xor.cljc
+++ b/test/clojure/core_test/bit_xor.cljc
@@ -3,8 +3,10 @@
             [clojure.core-test.number-range :as r]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (bit-xor nil 1)))
-  (t/is (thrown? NullPointerException (bit-xor 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-xor nil 1)))
+     :cljs (t/is (bit-xor nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (bit-xor 1 nil)))
+     :cljs (t/is (bit-xor 1 nil)))
 
   (t/are [ex a b] (= ex (bit-xor a b))
          2r0101 2r1100 2r1001

--- a/test/clojure/core_test/unsigned_bit_shift_right.cljc
+++ b/test/clojure/core_test/unsigned_bit_shift_right.cljc
@@ -2,8 +2,10 @@
   (:require [clojure.test :as t]))
 
 (t/deftest common
-  (t/is (thrown? NullPointerException (unsigned-bit-shift-right nil 1)))
-  (t/is (thrown? NullPointerException (unsigned-bit-shift-right 1 nil)))
+  #?(:clj (t/is (thrown? NullPointerException (unsigned-bit-shift-right nil 1)))
+     :cljs (t/is (unsigned-bit-shift-right nil 1)))
+  #?(:clj (t/is (thrown? NullPointerException (unsigned-bit-shift-right 1 nil)))
+     :cljs (t/is (unsigned-bit-shift-right 1 nil)))
 
   (t/are [ex a b] (= ex (unsigned-bit-shift-right a b))
          18014398509481983 -1 10))


### PR DESCRIPTION
Javascript is incredibly permissive so it allows this naughtiness.