### PR TITLE
Add tests for `inc` and `dec`

### DIFF
--- a/test/clojure/core_test/dec.cljc
+++ b/test/clojure/core_test/dec.cljc
@@ -1,0 +1,17 @@
+(ns clojure.core-test.dec
+  (:require [clojure.test :as t]))
+
+(t/deftest common
+  (t/are [in ex] (= (dec in) ex)
+    1 0
+    14412 14411
+    -3 -4))
+
+(t/deftest underflow
+  #?(:clj (t/is (thrown? ArithmeticException (dec Long/MIN_VALUE)))
+     :cljs (t/is (= (dec js/Number.MIN_SAFE_INTEGER) (- js/Number.MIN_SAFE_INTEGER 2)))))
+
+(t/deftest dec-nil
+  ;; ClojureScript says (= -1 (dec nil)) because JavaScript casts null to 0
+  #?(:clj (t/is (thrown? NullPointerException (dec #_:clj-kondo/ignore nil)))
+     :cljs (t/is (= -1 (dec #_:clj-kondo/ignore nil)))))

--- a/test/clojure/core_test/inc.cljc
+++ b/test/clojure/core_test/inc.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.inc
+  (:require [clojure.test :as t]))
+
+(t/deftest common
+  (t/are [in ex] (= (inc in) ex)
+    1 2
+    1465 1466
+    -5 -4))
+
+(t/deftest overflow
+  #?(:clj (t/is (thrown? ArithmeticException (inc Long/MAX_VALUE)))
+     :cljs (t/is (= (inc js/Number.MAX_SAFE_INTEGER) (+ 2 js/Number.MAX_SAFE_INTEGER)))))
+
+(t/deftest inc-nil
+  ;; ClojureScript says (= 1 (inc nil)) because JavaScript casts null to 0
+  ;; https://clojuredocs.org/clojure.core/inc#example-6156a59ee4b0b1e3652d754f
+  #?(:clj (t/is (thrown? NullPointerException (inc #_:clj-kondo/ignore nil)))
+     :cljs (t/is (= 1 (inc #_:clj-kondo/ignore nil)))))


### PR DESCRIPTION
The ClojureScript tests I've tested manually in a ClojureScript REPL, but not with `lein test` since ClojureScript support hasn't been implemented yet.