### PR TITLE
Add new tests for various symbols and keywords functions

### DIFF
--- a/test/clojure/core_test/ident_questionmark.cljc
+++ b/test/clojure/core_test/ident_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.ident-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-ident?
+  (are [expected x] (= expected (ident? x))
+    true  :a-keyword
+    true  'a-symbol
+    true  :a-ns/a-keyword
+    true  'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/intern.cljc
+++ b/test/clojure/core_test/intern.cljc
@@ -1,0 +1,23 @@
+(ns clojure.core-test.intern
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-intern
+  ;; Intern and bind
+  (let [x-var (intern 'clojure.core-test.intern 'x 42)]
+    (is (= 42 (var-get x-var))))
+
+  ;; Use intern to return the previously interned var
+  (let [x-var (intern 'clojure.core-test.intern 'x)]
+    (is (= 42 (var-get x-var))))
+
+  ;; Create new namespace and use that as argument to intern
+  (let [n (create-ns 'avoid-a-clash)
+        x-var (intern n 'x 42)]
+    (is (= 42 (var-get x-var))))
+
+  (let [x-var (intern 'avoid-a-clash 'x)]
+    (is (= 42 (var-get x-var))))
+
+  ;; Trying to intern to an unknown namespace should throw
+  (is (thrown? Exception (intern 'unknown-namespace 'x)))
+  (is (thrown? Exception (intern 'unknonw-namespace 'x 42))))

--- a/test/clojure/core_test/keyword.cljc
+++ b/test/clojure/core_test/keyword.cljc
@@ -1,0 +1,86 @@
+(ns clojure.core-test.keyword
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-keyword
+  ;; "Symbols begin with a non-numeric character and can contain
+  ;; alphanumeric characters and *, +, !, -, _, ', ?, <, > and =
+  ;; (other characters may be allowed eventually)."
+  ;; 
+  ;; "Keywords are like symbols, except: * They can and must begin with a colon, e.g. :fred."
+  ;;
+  ;; (see http://clojure.org/reader for details)
+  ;;
+  ;; From https://clojuredocs.org/clojure.core/keyword
+  ;; keyword does not validate input strings for ns and name, and may
+  ;; return improper keywords with undefined behavior for non-conformant
+  ;; ns and name.
+  
+  (are [expected name] (= expected (keyword name))
+    :abc "abc"
+    :abc 'abc
+    :abc :abc
+    :* "*"
+    :* '*
+    :* :*
+    :+ "+"
+    :+ '+
+    :+ :+
+    :! "!"
+    :! '!
+    :! :!
+    :- "-"
+    :- '-
+    :- :-
+    :_ "_"
+    :_ '_
+    :_ :_
+    :? "?"
+    :? '?
+    :? :?
+    :< "<"
+    :< '<
+    :< :<
+    :> ">"
+    :> '>
+    :> :>
+    := "="
+    := '=
+    := :=
+    :abc*+!-_'?<>= "abc*+!-_'?<>=")
+
+  (are [expected ns name] (= expected (keyword ns name))
+    :abc/abc     "abc"     "abc"
+    :abc.def/abc "abc.def" "abc"
+    
+    :*/abc "*" "abc"
+    :+/abc "+" "abc"
+    :!/abc "!" "abc"
+    :-/abc "-" "abc"
+    :_/abc "_" "abc"
+    :?/abc "?" "abc"
+    :</abc "<" "abc"
+    :>/abc ">" "abc"
+    :=/abc "=" "abc"
+
+    :abc.def/* "abc.def" "*"
+    :abc.def/+ "abc.def" "+"
+    :abc.def/! "abc.def" "!"
+    :abc.def/- "abc.def" "-"
+    :abc.def/_ "abc.def" "_"
+    :abc.def/? "abc.def" "?"
+    :abc.def/< "abc.def" "<"
+    :abc.def/> "abc.def" ">"
+    :abc.def/= "abc.def" "="
+
+    :abc*+!-_'?<>=/abc*+!-_'?<>= "abc*+!-_'?<>=" "abc*+!-_'?<>=")
+  
+  (is (nil? (keyword nil)))         ; (keyword nil) => nil, surprisingly
+  (is (= :abc (keyword nil "abc"))) ; But if ns is nil, it just ignores it.
+  (is (thrown? Exception (keyword "abc" nil))) ; But if name is nil, then we throw.
+  
+  ;; Two arg version requires namespace and symbol to be a string, not
+  ;; a symbol or keyword like the one arg version.
+  (is (thrown? Exception (keyword 'abc "abc")))
+  (is (thrown? Exception (keyword "abc" 'abc)))
+  (is (thrown? Exception (keyword :abc "abc")))
+  (is (thrown? Exception (keyword "abc" :abc))))

--- a/test/clojure/core_test/keyword_questionmark.cljc
+++ b/test/clojure/core_test/keyword_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.keyword-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-keyword?
+  (are [expected x] (= expected (keyword? x))
+    true  :a-keyword
+    false 'a-symbol
+    true  :a-ns/a-keyword
+    false 'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/name.cljc
+++ b/test/clojure/core_test/name.cljc
@@ -1,0 +1,14 @@
+(ns clojure.core-test.name
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-name
+  (are [expected x] (= expected (name x))
+  "abc" "abc"
+  "abc" :abc
+  "abc" 'abc
+  "def" :abc/def
+  "def" 'abc/def
+  "abc*+!-_'?<>=" :abc/abc*+!-_'?<>=
+  "abc*+!-_'?<>=" 'abc/abc*+!-_'?<>=)
+
+  (is (thrown? Exception (name nil))))

--- a/test/clojure/core_test/namespace.cljc
+++ b/test/clojure/core_test/namespace.cljc
@@ -1,0 +1,12 @@
+(ns clojure.core-test.namespace
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-namespace
+  (are [expected sym-or-kw] (= expected (namespace sym-or-kw))
+    "clojure.core" 'clojure.core/+
+    "abc"          :abc/def
+    "abc"          'abc/def
+    nil            :abc
+    nil            'abc)
+  
+  (is (thrown? Exception (namespace nil))))

--- a/test/clojure/core_test/qualified_ident_questionmark.cljc
+++ b/test/clojure/core_test/qualified_ident_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.qualified-ident-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-qualified-ident?
+  (are [expected x] (= expected (qualified-ident? x))
+    false :a-keyword
+    false 'a-symbol
+    true  :a-ns/a-keyword
+    true  'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/qualified_keyword_questionmark.cljc
+++ b/test/clojure/core_test/qualified_keyword_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.qualified-keyword-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-qualified-keyword?
+  (are [expected x] (= expected (qualified-keyword? x))
+    false :a-keyword
+    false 'a-symbol
+    true  :a-ns/a-keyword
+    false 'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/qualified_symbol_questionmark.cljc
+++ b/test/clojure/core_test/qualified_symbol_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.qualified-symbol-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-qualified-symbol?
+  (are [expected x] (= expected (qualified-symbol? x))
+    false :a-keyword
+    false 'a-symbol
+    false :a-ns/a-keyword
+    true  'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/simple_ident_questionmark.cljc
+++ b/test/clojure/core_test/simple_ident_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.simple-ident-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-simple-ident?
+  (are [expected x] (= expected (simple-ident? x))
+    true  :a-keyword
+    true  'a-symbol
+    false :a-ns/a-keyword
+    false 'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/simple_keyword_questionmark.cljc
+++ b/test/clojure/core_test/simple_keyword_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.simple-keyword-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-simple-keyword?
+  (are [expected x] (= expected (simple-keyword? x))
+    true  :a-keyword
+    false 'a-symbol
+    false :a-ns/a-keyword
+    false 'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/simple_symbol_questionmark.cljc
+++ b/test/clojure/core_test/simple_symbol_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.simple-symbol-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-simple-symbol?
+  (are [expected x] (= expected (simple-symbol? x))
+    false :a-keyword
+    true  'a-symbol
+    false :a-ns/a-keyword
+    false 'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))

--- a/test/clojure/core_test/symbol.cljc
+++ b/test/clojure/core_test/symbol.cljc
@@ -1,0 +1,88 @@
+(ns clojure.core-test.symbol
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-symbol
+  ;; "Symbols begin with a non-numeric character and can contain
+  ;; alphanumeric characters and *, +, !, -, _, ', ?, <, > and =
+  ;; (other characters may be allowed eventually)."
+  ;; (see http://clojure.org/reader for details)
+  ;;
+  ;; From https://clojuredocs.org/clojure.core/keyword
+  ;; keyword does not validate input strings for ns and name, and may
+  ;; return improper keywords with undefined behavior for non-conformant
+  ;; ns and name.
+  
+  (are [expected name] (= expected (symbol name))
+    'abc "abc"
+    'abc 'abc
+    'abc :abc
+    '* "*"
+    '* '*
+    '* :*
+    '+ "+"
+    '+ '+
+    '+ :+
+    '! "!"
+    '! '!
+    '! :!
+    '- "-"
+    '- '-
+    '- :-
+    '_ "_"
+    '_ '_
+    '_ :_
+    '? "?"
+    '? '?
+    '? :?
+    '< "<"
+    '< '<
+    '< :<
+    '> ">"
+    '> '>
+    '> :>
+    '= "="
+    '= '=
+    '= :=
+    'abc*+!-_'?<>= "abc*+!-_'?<>=")
+
+  (are [expected ns name] (= expected (symbol ns name))
+    'abc/abc     "abc"     "abc"
+    'abc.def/abc "abc.def" "abc"
+    
+    '*/abc "*" "abc"
+    '+/abc "+" "abc"
+    '!/abc "!" "abc"
+    '-/abc "-" "abc"
+    '_/abc "_" "abc"
+    '?/abc "?" "abc"
+    '</abc "<" "abc"
+    '>/abc ">" "abc"
+    '=/abc "=" "abc"
+
+    'abc.def/* "abc.def" "*"
+    'abc.def/+ "abc.def" "+"
+    'abc.def/! "abc.def" "!"
+    'abc.def/- "abc.def" "-"
+    'abc.def/_ "abc.def" "_"
+    'abc.def/? "abc.def" "?"
+    'abc.def/< "abc.def" "<"
+    'abc.def/> "abc.def" ">"
+    'abc.def/= "abc.def" "="
+
+    'abc*+!-_'?<>=/abc*+!-_'?<>= "abc*+!-_'?<>=" "abc*+!-_'?<>=")
+  
+  (is (thrown? Exception (symbol nil)))       ; keyword returns nil
+  (is (= 'abc (symbol nil "abc")))            ; But if ns is nil, it just ignores it.
+
+  ;; prints as 'abc/null but the null is really a nil. Since this is
+  ;; not readable via the standard Clojure reader, I'm not even sure
+  ;; how to test this case here. That's why it's commented out.
+  ;; Note that `keyword` throws for this case.
+  ;; (is (= 'abc/null (symbol "abc" nil)))
+  
+  ;; Two arg version requires namespace and symbol to be a string, not
+  ;; a symbol or keyword like the one arg version.
+  (is (thrown? Exception (symbol 'abc "abc")))
+  (is (thrown? Exception (symbol "abc" 'abc)))
+  (is (thrown? Exception (symbol :abc "abc")))
+  (is (thrown? Exception (symbol "abc" :abc))))

--- a/test/clojure/core_test/symbol_questionmark.cljc
+++ b/test/clojure/core_test/symbol_questionmark.cljc
@@ -1,0 +1,18 @@
+(ns clojure.core-test.symbol-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-symbol?
+  (are [expected x] (= expected (symbol? x))
+    false :a-keyword
+    true  'a-symbol
+    false :a-ns/a-keyword
+    true  'a-ns/a-keyword
+    false "a string"
+    false 0
+    false 0N
+    false 0.0
+    false 1/2
+    false 0.0M
+    false false
+    false true
+    false nil))


### PR DESCRIPTION
Add new tests for

- `keyword`
- `symbol`
- `name`
- `intern`
- `namespace`
- `keyword?`
- `symbol?`
- `ident?`
- `simple-keyword?`
- `simple-symbol?`
- `simple-ident?`
- `qualified-keyword?`
- `qualified-symbol?`
- `qualified-ident?`
