### PR TITLE
Add tests for various string output functions

### DIFF
--- a/test/clojure/core_test/char.cljc
+++ b/test/clojure/core_test/char.cljc
@@ -1,0 +1,16 @@
+(ns clojure.core-test.char
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-char
+  (are [expected x] (= expected (char x))
+    ;; Assumes ASCII / Unicode
+    \space 32
+    \@     64
+    \A     65
+    \A     \A
+    ;; TODO: Add Unicode tests
+    )
+
+  (is (thrown? IllegalArgumentException (char -1)))
+  (is (thrown? Exception (char nil))))
+

--- a/test/clojure/core_test/char_questionmark.cljc
+++ b/test/clojure/core_test/char_questionmark.cljc
@@ -1,0 +1,54 @@
+(ns clojure.core-test.char-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.number-range :as r]))
+
+(deftest test-char?
+  (are [expected x] (= expected (char? x))
+    false 0
+    false 1
+    false -1
+    false r/max-int
+    false r/min-int
+    false 0.0
+    false 1.0
+    false -1.0
+    false (float 0.0)
+    false (float 1.0)
+    false (float -1.0)
+    false (double 0.0)
+    false (double 1.0)
+    false (double -1.0)
+    false r/max-double
+    false r/min-double
+    false ##Inf
+    false ##-Inf
+    false ##NaN
+    false 0N
+    false 1N
+    false -1N
+    false 0/2
+    false 1/2
+    false -1/2
+    false 0.0M
+    false 1.0M
+    false -1.0M
+    false nil
+    false true
+    false false
+    false "a string"
+    false "0"
+    false "1"
+    false "-1"
+    false {:a :map}
+    false #{:a-set}
+    false [:a :vector]
+    false '(:a :list)
+    true  \0
+    true  \1
+    true  \A
+    true  \space
+    false :a-keyword
+    false :0
+    false :1
+    false :-1
+    false 'a-sym))

--- a/test/clojure/core_test/format.cljc
+++ b/test/clojure/core_test/format.cljc
@@ -1,0 +1,19 @@
+(ns clojure.core-test.format
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+;;; Note that `format` presents a bit of a conundrum for
+;;; testing. Clojure JVM delegates the formatting task to
+;;; Java. ClojureScript doesn't implement `format`. Other Clojure
+;;; implementations may take different paths. Even when `format` is
+;;; implemented, the full scope of Java's `java.util.Formatter`
+;;; functionality may not be there. Thus, we take a very conservative
+;;; approach here for the default case of just testing to verify that
+;;; the function exists and that a simple format string with no escape
+;;; characters passes through `format` unharmed.
+;;; See: https://clojurians.slack.com/archives/C03SRH97FDK/p1733853098700809
+
+(deftest test-format
+  #?@(:cljs nil                         ; CLJS doesn't have `format`
+      :default
+      [(is (= "test" (format "test")))])
+  )

--- a/test/clojure/core_test/pr_str.cljc
+++ b/test/clojure/core_test/pr_str.cljc
@@ -1,0 +1,7 @@
+(ns clojure.core-test.pr-str
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-pr-str
+  (is (= "\"a\" \"string\"" (pr-str "a" "string")))
+  (is (= "nil \"a\" \"string\" \\A \\space 1 17.0 [:a :b] {:c :d} #{:e}"
+         (pr-str nil "a" "string" \A \space 1 17.0 [:a :b] {:c :d} #{:e}))))

--- a/test/clojure/core_test/print_str.cljc
+++ b/test/clojure/core_test/print_str.cljc
@@ -1,0 +1,7 @@
+(ns clojure.core-test.print-str
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-print-str
+  (is (= "a string" (print-str "a" "string")))
+  (is (= "nil a string A   1 17.0 [:a :b] {:c :d} #{:e}"
+           (print-str nil "a" "string" \A \space 1 17.0 [:a :b] {:c :d} #{:e}))))

--- a/test/clojure/core_test/println_str.cljc
+++ b/test/clojure/core_test/println_str.cljc
@@ -1,0 +1,13 @@
+(ns clojure.core-test.println-str
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-println-str
+  (let [nl (println-str)]
+    ;; `nl` grabs the platform specific newline without calling out to
+    ;; platform-specific code (e.g., Java) since we want this to run
+    ;; in all environments. Note that we're not actually testing
+    ;; whether the newline sequence itself is correct, only that
+    ;; `println-str` adds it to the end of the string.
+    (is (= (str "a string" nl) (println-str "a" "string")))
+    (is (= (str "nil a string A   1 17.0 [:a :b] {:c :d} #{:e}" nl)
+           (println-str nil "a" "string" \A \space 1 17.0 [:a :b] {:c :d} #{:e})))))

--- a/test/clojure/core_test/prn_str.cljc
+++ b/test/clojure/core_test/prn_str.cljc
@@ -1,0 +1,13 @@
+(ns clojure.core-test.prn-str
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-prn-str
+  (let [nl (prn-str)]
+    ;; `nl` grabs the platform specific newline without calling out to
+    ;; platform-specific code (e.g., Java) since we want this to run
+    ;; in all environments. Note that we're not actually testing
+    ;; whether the newline sequence itself is correct, only that
+    ;; `prn-str` adds it to the end of the string.
+    (is (= (str "\"a\" \"string\"" nl) (prn-str "a" "string")))
+    (is (= (str "nil \"a\" \"string\" \\A \\space 1 17.0 [:a :b] {:c :d} #{:e}" nl)
+           (prn-str nil "a" "string" \A \space 1 17.0 [:a :b] {:c :d} #{:e})))))

--- a/test/clojure/core_test/str.cljc
+++ b/test/clojure/core_test/str.cljc
@@ -1,0 +1,55 @@
+(ns clojure.core-test.str
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.number-range :as r]))
+
+(deftest test-str
+  (are [expected x] (= expected (str x))
+    "0"            0
+    "1"            1
+    "-1"           -1
+    "0.0"          0.0
+    "1.0"          1.0
+    "-1.0"         -1.0
+    "0.0"          0.00000
+    "0.0"          (float 0.0)
+    "1.0"          (float 1.0)
+    "-1.0"         (float -1.0)
+    "0.0"          (double 0.0)
+    "1.0"          (double 1.0)
+    "-1.0"         (double -1.0)
+    "Infinity"     ##Inf
+    "-Infinity"    ##-Inf
+    "NaN"          ##NaN
+    "0"            0N
+    "1"            1N
+    "-1"           -1N
+    "0"            0/2
+    "1/2"          1/2
+    "-1/2"         -1/2
+    "0.0"          0.0M
+    "1.0"          1.0M
+    "-1.0"         -1.0M
+    ""             nil
+    "true"         true
+    "false"        false
+    "a string"     "a string"
+    "0"            "0"
+    "1"            "1"
+    "-1"           "-1"
+    "{:a :map}"    {:a :map}            ; keep this one item because it's unordered
+    "#{:a-set}"    #{:a-set}            ; keep this one item because it's unordered
+    "[:a :vector]" [:a :vector]
+    "(:a :list)"   '(:a :list)
+    "0"            \0
+    "1"            \1
+    "A"            \A
+    " "            \space
+    ":a-keyword"   :a-keyword
+    ":0"           :0
+    ":1"           :1
+    ":-1"          :-1
+    "a-sym"        'a-sym)
+
+  ;; No arg and var arg versions
+  (is (= "" (str)))
+  (is (= "astringwithnospaces" (str "a" "string" "with" "no" "spaces"))))

--- a/test/clojure/core_test/string_questionmark.cljc
+++ b/test/clojure/core_test/string_questionmark.cljc
@@ -1,0 +1,54 @@
+(ns clojure.core-test.string-questionmark
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.number-range :as r]))
+
+(deftest test-string?
+  (are [expected x] (= expected (string? x))
+    false 0
+    false 1
+    false -1
+    false r/max-int
+    false r/min-int
+    false 0.0
+    false 1.0
+    false -1.0
+    false (float 0.0)
+    false (float 1.0)
+    false (float -1.0)
+    false (double 0.0)
+    false (double 1.0)
+    false (double -1.0)
+    false r/max-double
+    false r/min-double
+    false ##Inf
+    false ##-Inf
+    false ##NaN
+    false 0N
+    false 1N
+    false -1N
+    false 0/2
+    false 1/2
+    false -1/2
+    false 0.0M
+    false 1.0M
+    false -1.0M
+    false nil
+    false true
+    false false
+    true "a string"
+    true "0"
+    true "1"
+    true "-1"
+    false {:a :map}
+    false #{:a-set}
+    false [:a :vector]
+    false '(:a :list)
+    false  \0
+    false  \1
+    false \A
+    false \space
+    false :a-keyword
+    false :0
+    false :1
+    false :-1
+    false 'a-sym))

--- a/test/clojure/core_test/subs.cljc
+++ b/test/clojure/core_test/subs.cljc
@@ -1,0 +1,19 @@
+(ns clojure.core-test.subs
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-subs
+  (is (= "bcde" (subs "abcde" 1)))
+  (is (= "bcd" (subs "abcde" 1 4)))
+  (is (= "abc" (subs "abcde" 0 3)))
+  (is (= "" (subs "abcde" 0 0)))
+  (is (= "" (subs "abcde" 5)))
+  (is (= "" (subs "abcde" 5 5)))
+  (is (thrown? StringIndexOutOfBoundsException (subs "abcde" 2 1)))
+  (is (thrown? StringIndexOutOfBoundsException (subs "abcde" 1 6)))
+  (is (thrown? StringIndexOutOfBoundsException (subs "abcde" 1 200)))
+  (is (thrown? StringIndexOutOfBoundsException (subs "abcde" -1)))
+  (is (thrown? StringIndexOutOfBoundsException (subs "abcde" -1 3)))
+  (is (thrown? StringIndexOutOfBoundsException (subs "abcde" -1 -3)))
+  (is (thrown? Exception (subs nil 1 2)))
+  (is (thrown? Exception (subs "abcde" nil 2)))
+  (is (thrown? Exception (subs "abcde" 1 nil))))

--- a/test/clojure/core_test/with_out_str.cljc
+++ b/test/clojure/core_test/with_out_str.cljc
@@ -1,0 +1,9 @@
+(ns clojure.core-test.with-out-str
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-with-out-str
+  (is (= (str "some sample :text here" (println-str)
+              "[:a :b] {:c :d} #{:e} (:f)" (prn-str))
+         (with-out-str
+           (println "some" "sample" :text 'here)
+           (prn [:a :b] {:c :d} #{:e} '(:f))))))


### PR DESCRIPTION
Add tests for

- `char`
- `char?`
- `format`
- `pr-str`
- `print-str`
- `println-str`
- `prn-str`
- `str`
- `string?`
- `subs`
- `with-out-str`
