### PR TITLE
Add tests for various numeric casts

### DIFF
--- a/test/clojure/core_test/bigdec.cljc
+++ b/test/clojure/core_test/bigdec.cljc
@@ -1,0 +1,24 @@
+(ns clojure.core-test.bigdec
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-bigdec
+  (are [expected x] (= expected (bigdec x))
+    1M    1
+    0M    0
+    -1M   -1
+    1M    1N
+    0M    0N
+    -1M   -1N
+    1M    1.0
+    0M    0.0
+    -1M   -1.0
+    0.5M  1/2
+    0M    0/2
+    -0.5M -1/2)
+
+  ;; `bigdec` must produce objects that satisfy `decimal?`
+  (is (decimal? (bigdec 1)))
+
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.math.BigDecimal (bigdec 1)))]))

--- a/test/clojure/core_test/bigint.cljc
+++ b/test/clojure/core_test/bigint.cljc
@@ -1,0 +1,28 @@
+(ns clojure.core-test.bigint
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.number-range :as r]))
+
+(deftest test-bigint
+  (are [expected x] (= expected (bigint x))
+    1N  1
+    0N  0
+    -1N -1
+    #?@(:cljs nil
+        :clj [179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000N r/max-double])
+    1N  1.0
+    0N  0.0
+    -1N -1.0
+    1N  12/12
+    0N  0/12
+    -1N -12/12)
+
+  ;; Validate that we correctly promote from int to bigint with `inc'` and `dec'`.
+  (is (= 9223372036854775808N (inc (bigint r/max-int)) (inc' r/max-int)))
+  (is (= -9223372036854775809N (dec (bigint r/min-int)) (dec' r/min-int)))
+
+  #?@(:cljs nil
+      :default
+      [(is (instance? clojure.lang.BigInt (bigint 0)))
+       (is (instance? clojure.lang.BigInt (bigint 0.0)))
+       (is (instance? clojure.lang.BigInt (inc' r/max-int)))
+       (is (instance? clojure.lang.BigInt (dec' r/min-int)))]))

--- a/test/clojure/core_test/byte.cljc
+++ b/test/clojure/core_test/byte.cljc
@@ -1,0 +1,46 @@
+(ns clojure.core-test.byte
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-byte
+  ;; There is no platform independent predicate to test for a
+  ;; byte (e.g., `byte?`). In ClojureJVM, it's an instance of
+  ;; `java.lang.Byte`, but there is no predicate for it. Here, we just
+  ;; test whether it's a fixed-length integer of some sort.
+  (is (int? (byte 0)))
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.lang.Byte (byte 0)))])
+
+  ;; Check conversions and rounding from other numeric types
+  (are [expected x] (= expected (byte x))
+    -128 -128
+    0    0
+    127  127
+    1    1N
+    0    0N
+    -1   -1N
+    1    1.0M
+    0    0.0M
+    -1   -1.0M
+    1    1.1
+    -1   -1.1
+    1    1.9
+    1    3/2
+    -1   -3/2
+    0    1/10
+    0    -1/10
+    1    1.1M
+    -1   -1.1M)
+
+  ;; `byte` throws outside the range of 127 ... -128.
+  (is (thrown? IllegalArgumentException (byte -128.000001)))
+  (is (thrown? IllegalArgumentException (byte -129)))
+  (is (thrown? IllegalArgumentException (byte 128)))
+  (is (thrown? IllegalArgumentException (byte 127.000001)))
+
+  ;; Check handling of other types
+  (is (thrown? ClassCastException (byte "0")))
+  (is (thrown? ClassCastException (byte :0)))
+  (is (thrown? ClassCastException (byte [0])))
+  (is (thrown? Exception (byte nil))))
+

--- a/test/clojure/core_test/double.cljc
+++ b/test/clojure/core_test/double.cljc
@@ -1,0 +1,27 @@
+(ns clojure.core-test.double
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-double
+  (are [expected x] (= expected (double x))
+    (double 1.0) 1
+    (double 0.0) 0
+    (double -1.0) -1
+    (double 1.0) 1N
+    (double 0.0) 0N
+    (double -1.0) -1N
+    (double 1.0) 12/12
+    (double 0.0) 0/12
+    (double -1.0) -12/12
+    (double 1.0) 1.0M
+    (double 0.0) 0.0M
+    (double -1.0) -1.0M)
+  (is (NaN? (double ##NaN)))
+
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.lang.Double (double 0)))
+       (is (instance? java.lang.Double (double 0.0)))
+       (is (instance? java.lang.Double (double 0N)))
+       (is (instance? java.lang.Double (double 0.0M)))])
+  (is (thrown? ClassCastException (double "0")))
+  (is (thrown? ClassCastException (double :0))))

--- a/test/clojure/core_test/float.cljc
+++ b/test/clojure/core_test/float.cljc
@@ -1,0 +1,33 @@
+(ns clojure.core-test.float
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.number-range :as r]))
+
+(deftest test-float
+  (are [expected x] (= expected (float x))
+    (float 1.0) 1
+    (float 0.0) 0
+    (float -1.0) -1
+    (float 1.0) 1N
+    (float 0.0) 0N
+    (float -1.0) -1N
+    (float 1.0) 12/12
+    (float 0.0) 0/12
+    (float -1.0) -12/12
+    (float 1.0) 1.0M
+    (float 0.0) 0.0M
+    (float -1.0) -1.0M
+    (float 0.0) r/min-double)
+  (is (NaN? (float ##NaN)))
+
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.lang.Float (float 0)))
+       (is (instance? java.lang.Float (float 0.0)))
+       (is (instance? java.lang.Float (float 0N)))
+       (is (instance? java.lang.Float (float 0.0M)))])
+
+  (is (thrown? IllegalArgumentException (float r/max-double)))
+  (is (thrown? IllegalArgumentException (float ##Inf)))
+  (is (thrown? IllegalArgumentException (float ##-Inf)))
+  (is (thrown? ClassCastException (float "0")))
+  (is (thrown? ClassCastException (float :0))))

--- a/test/clojure/core_test/int.cljc
+++ b/test/clojure/core_test/int.cljc
@@ -1,0 +1,48 @@
+(ns clojure.core-test.int
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-int
+  ;; There is no platform independent predicate to test specifically
+  ;; for an int. While `int?` exists, it returns true for any
+  ;; fixed-range integer type (e.g., byte, short, int, or long). In
+  ;; ClojureJVM, it's an instance of `java.lang.Int`, but there is no
+  ;; predicate for it. Here, we just test whether it's a fixed-length
+  ;; integer of some sort.
+  (is (int? (int 0)))
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.lang.Integer (int 0)))])
+
+  ;; Check conversions and rounding from other numeric types
+  (are [expected x] (= expected (int x))
+    -2147483648 -2147483648
+    0    0
+    2147483647 2147483647
+    1    1N
+    0    0N
+    -1   -1N
+    1    1.0M
+    0    0.0M
+    -1   -1.0M
+    1    1.1
+    -1   -1.1
+    1    1.9
+    1    3/2
+    -1   -3/2
+    0    1/10
+    0    -1/10
+    1    1.1M
+    -1   -1.1M)
+
+  ;; `int` throws outside the range of 32767 ... -32768.
+  (is (thrown? IllegalArgumentException (int -2147483648.000001)))
+  (is (thrown? ArithmeticException (int -2147483649)))
+  (is (thrown? ArithmeticException (int 2147483648)))
+  (is (thrown? IllegalArgumentException (int 2147483647.000001)))
+
+  ;; Check handling of other types
+  (is (thrown? ClassCastException (int "0")))
+  (is (thrown? ClassCastException (int :0)))
+  (is (thrown? ClassCastException (int [0])))
+  (is (thrown? Exception (int nil))))
+

--- a/test/clojure/core_test/long.cljc
+++ b/test/clojure/core_test/long.cljc
@@ -1,0 +1,44 @@
+(ns clojure.core-test.long
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-long
+  ;; There is no platform independent predicate to test specifically
+  ;; for a long. In ClojureJVM, it's an instance of `java.lang.Long`,
+  ;; but there is no predicate for it. Here, we just test whether it's
+  ;; a fixed-length integer of some sort.
+  (is (int? (int 0)))
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.lang.Long (long 0)))])
+
+  ;; Check conversions and rounding from other numeric types
+  (are [expected x] (= expected (long x))
+    -9223372036854775808 -9223372036854775808
+    0    0
+    9223372036854775807 9223372036854775807
+    1    1N
+    0    0N
+    -1   -1N
+    1    1.0M
+    0    0.0M
+    -1   -1.0M
+    1    1.1
+    -1   -1.1
+    1    1.9
+    1    3/2
+    -1   -3/2
+    0    1/10
+    0    -1/10
+    1    1.1M
+    -1   -1.1M)
+
+  ;; `long` throws outside the range of 9223372036854775807 ... -9223372036854775808
+  (is (thrown? IllegalArgumentException (long -9223372036854775809)))
+  (is (thrown? IllegalArgumentException (long 9223372036854775808)))
+
+  ;; Check handling of other types
+  (is (thrown? ClassCastException (long "0")))
+  (is (thrown? ClassCastException (long :0)))
+  (is (thrown? ClassCastException (long [0])))
+  (is (thrown? Exception (long nil))))
+

--- a/test/clojure/core_test/num.cljc
+++ b/test/clojure/core_test/num.cljc
@@ -1,0 +1,14 @@
+(ns clojure.core-test.num
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-num
+  #?@(:cljs nil
+      :default
+      ;; The compiler should pass `x` as a primitive to `num`.
+      [(let [x 1.0]
+         (is (instance? java.lang.Double (num x))))
+       (let [x 1]
+         (is (instance? java.lang.Long (num x))))
+       ;; `BigInt` and `BigDecimal` are always boxed and `num` just returns them as-is.
+       (is (instance? clojure.lang.BigInt (num 1N)))
+       (is (instance? java.math.BigDecimal (num 1.0M)))]))

--- a/test/clojure/core_test/rationalize.cljc
+++ b/test/clojure/core_test/rationalize.cljc
@@ -1,0 +1,24 @@
+(ns clojure.core-test.rationalize
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-rationalize
+  (are [expected x] (let [x' (rationalize x)]
+                      (and (= expected x')
+                           (or (integer? x')
+                               (ratio? x'))))
+    1                                  1
+    0                                  0
+    -1                                 -1
+    1N                                 1N
+    0N                                 0N
+    -1N                                -1N
+    1                                  1.0
+    0                                  0.0
+    -1                                 -1.0
+    3/2                                1.5
+    11/10                              1.1
+    3333333333333333/10000000000000000 (/ 1.0 3.0)
+    1                                  1.0M
+    0                                  0.0M
+    3/2                                1.5M
+    11/10                              1.1M))

--- a/test/clojure/core_test/short.cljc
+++ b/test/clojure/core_test/short.cljc
@@ -1,0 +1,46 @@
+(ns clojure.core-test.short
+  (:require [clojure.test :as t :refer [deftest testing is are]]))
+
+(deftest test-short
+  ;; There is no platform independent predicate to test for a
+  ;; short (e.g., `short?`). In ClojureJVM, it's an instance of
+  ;; `java.lang.Short`, but there is no predicate for it. Here, we just
+  ;; test whether it's a fixed-length integer of some sort.
+  (is (int? (short 0)))
+  #?@(:cljs nil
+      :default
+      [(is (instance? java.lang.Short (short 0)))])
+
+  ;; Check conversions and rounding from other numeric types
+  (are [expected x] (= expected (short x))
+    -32768 -32768
+    0    0
+    32767 32767
+    1    1N
+    0    0N
+    -1   -1N
+    1    1.0M
+    0    0.0M
+    -1   -1.0M
+    1    1.1
+    -1   -1.1
+    1    1.9
+    1    3/2
+    -1   -3/2
+    0    1/10
+    0    -1/10
+    1    1.1M
+    -1   -1.1M)
+
+  ;; `short` throws outside the range of 32767 ... -32768.
+  (is (thrown? IllegalArgumentException (short -32768.000001)))
+  (is (thrown? IllegalArgumentException (short -32769)))
+  (is (thrown? IllegalArgumentException (short 32768)))
+  (is (thrown? IllegalArgumentException (short 32767.000001)))
+
+  ;; Check handling of other types
+  (is (thrown? ClassCastException (short "0")))
+  (is (thrown? ClassCastException (short :0)))
+  (is (thrown? ClassCastException (short [0])))
+  (is (thrown? Exception (short nil))))
+


### PR DESCRIPTION
Add tests for:

- `byte`
- `short`
- `int`
- `long`
- `float`
- `double`
- `bigint`
- `bigdec`
- `num`
- `rationalize`
