### PR TITLE
Add cases for zero arg, one arg, and multi-arg to arithmetic fns

### DIFF
--- a/test/clojure/core_test/minus.cljc
+++ b/test/clojure/core_test/minus.cljc
@@ -64,6 +64,9 @@
     5.0M  10.0M 5.0M
     -1.0M 1.0M  2.0M)
 
+  ;; Zero arg
+  (is (thrown? Exception (-)))
+
   ;; Single arg
   (is (= -3 (- 3)))
   (is (= 3 (- -3)))

--- a/test/clojure/core_test/plus.cljc
+++ b/test/clojure/core_test/plus.cljc
@@ -59,6 +59,16 @@
     6N 1N 5
     6N 1N 5N)
 
+  ;; Zero arg
+  (is (= 0 (+)))
+
+  ;; One arg
+  (is (= 1 (+ 1)))
+  (is (= 2 (+ 2)))
+
+  ;; Multi arg
+  (is (= 45 (+ 0 1 2 3 4 5 6 7 8 9)))
+
 
   (is (thrown? Exception (+ 1 nil)))
   (is (thrown? Exception (+ nil 1)))

--- a/test/clojure/core_test/slash.cljc
+++ b/test/clojure/core_test/slash.cljc
@@ -109,6 +109,9 @@
     -1.0M -1.0M 1.0M
     1.0M  -1.0M -1.0M)
 
+  ;; Zero arg
+  (is (thrown? Exception (/)))
+
   ;; Single arg 
   (is (= 1/2 (/ 2)))
   (is (= 0.5 (/ 2.0)))

--- a/test/clojure/core_test/star.cljc
+++ b/test/clojure/core_test/star.cljc
@@ -59,6 +59,16 @@
     5 1N 5
     5 1N 5N)
 
+  ;; Zero arg
+  (is (= 1 (*)))
+
+  ;; One arg
+  (is (= 1 (* 1)))
+  (is (= 2 (* 2)))
+
+  ;; Multi arg
+  (is (= 362880 (* 1 2 3 4 5 6 7 8 9)))
+
   (is (thrown? Exception (* 1 nil)))
   (is (thrown? Exception (* nil 1)))
 


### PR DESCRIPTION
Adds some test cases for zero arg, single arg, and multi-arg to arithmetic functions (`+`, `-`, `*`, and `/`).