### PR TITLE
Add tests for `quot`, `rem`, and `mod`

### DIFF
--- a/test/clojure/core_test/mod.cljc
+++ b/test/clojure/core_test/mod.cljc
@@ -1,0 +1,85 @@
+(ns clojure.core-test.mod
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.portability :as p]))
+
+(deftest test-mod
+  (are [type-pred expected x y] (let [r (mod x y)]
+                                  (and (type-pred r)
+                                       (= expected r)))
+    int? 1  10  3
+    int? 2  -10 3
+    int? -1 -10 -3
+    int? -2 10  -3
+
+    p/big-int? 1N  10  3N
+    p/big-int? 2N  -10 3N
+    p/big-int? -1N -10 -3N
+    p/big-int? -2N 10  -3N
+
+    p/big-int? 1N  10N  3
+    p/big-int? 2N  -10N 3
+    p/big-int? -1N -10N -3
+    p/big-int? -2N 10N  -3
+
+    p/big-int? 1N  10N  3N
+    p/big-int? 2N  -10N 3N
+    p/big-int? -1N -10N -3N
+    p/big-int? -2N 10N  -3N
+
+    double? 1.0  10    3.0
+    double? 2.0  -10   3.0
+    double? -1.0 -10   -3.0
+    double? -2.0 10    -3.0
+    double? 1.0  10.0  3
+    double? 2.0  -10.0 3
+    double? -1.0 -10.0 -3
+    double? -2.0 10.0  -3
+    double? 1.0  10.0  3.0
+    double? 2.0  -10.0 3.0
+    double? -1.0 -10.0 -3.0
+    double? -2.0 10.0  -3.0
+
+    decimal? 1.0M  10     3.0M
+    decimal? 2.0M  -10    3.0M
+    decimal? -1.0M -10    -3.0M
+    decimal? -2.0M 10     -3.0M
+    decimal? 1.0M  10.0M  3
+    decimal? 2.0M  -10.0M 3
+    decimal? -1.0M -10.0M -3
+    decimal? -2.0M 10.0M  -3
+    decimal? 1.0M  10.0M  3.0M
+    decimal? 2.0M  -10.0M 3.0M
+    decimal? -1.0M -10.0M -3.0M
+    decimal? -2.0M 10.0M  -3.0M
+
+    ;; Unexpectedly downconverts result to double, rather than BigDecimal
+    double? 1.0  10.0M  3.0
+    double? 2.0  -10.0M 3.0
+    double? -1.0 -10.0M -3.0
+    double? -2.0 10.0M  -3.0
+    double? 1.0  10.0   3.0M
+    double? 2.0  -10.0  3.0M
+    double? -1.0 -10.0  -3.0M
+    double? -2.0 10.0   -3.0M
+
+    p/big-int? 0N    3     1/2
+    ratio?     1/3   3     4/3
+    ratio?     7/2   37/2  15
+    p/big-int? 0N    3     -1/2
+    p/big-int? -1N   3     -4/3
+    ratio?     -23/2 37/2  -15
+    p/big-int? 0N    -3    1/2
+    p/big-int? 1N    -3    4/3
+    ratio?     23/2  -37/2 15
+    p/big-int? 0N    -3    -1/2
+    ratio?     -1/3  -3    -4/3
+    ratio?     -7/2  -37/2 -15)
+
+  (is (thrown? Exception (mod 10 0)))
+  (is (thrown? Exception (mod ##Inf 1))) ; surprising since (/ ##Inf 1) = ##Inf
+  (is (NaN? (mod 1 ##Inf)))
+  (is (thrown? Exception (mod ##-Inf 1))) ; surprising since (/ ##-Inf 1) = ##-Inf
+  (is (NaN? (mod 1 ##-Inf)))
+  (is (thrown? Exception (mod ##NaN 1)))
+  (is (thrown? Exception (mod 1 ##NaN)))
+  (is (thrown? Exception (mod ##NaN 1))))

--- a/test/clojure/core_test/portability.cljc
+++ b/test/clojure/core_test/portability.cljc
@@ -1,0 +1,5 @@
+(ns clojure.core-test.portability)
+
+(defn big-int? [n]
+  (and (integer? n)
+       (not (int? n))))

--- a/test/clojure/core_test/quot.cljc
+++ b/test/clojure/core_test/quot.cljc
@@ -1,0 +1,86 @@
+(ns clojure.core-test.quot
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.portability :as p]))
+
+(deftest test-quot
+  (are [type-pred expected x y] (let [r (quot x y)]
+                                  (and (type-pred r)
+                                       (= expected r)))
+    int? 3  10  3
+    int? -3 -10 3
+    int? 3  -10 -3
+    int? -3 10  -3
+
+    p/big-int? 3N  10   3N
+    p/big-int? -3N -10  3N
+    p/big-int? 3N  -10  -3N
+    p/big-int? -3N 10   -3N
+    p/big-int? 3N  10N  3
+    p/big-int? -3N -10N 3
+    p/big-int? 3N  -10N -3
+    p/big-int? -3N 10N  -3
+    p/big-int? 3N  10N  3N
+    p/big-int? -3N -10N 3N
+    p/big-int? 3N  -10N -3N
+    p/big-int? -3N 10N  -3N
+
+    double? 3.0  10    3.0
+    double? -3.0 -10   3.0
+    double? 3.0  -10   -3.0
+    double? -3.0 10    -3.0
+    double? 3.0  10.0  3
+    double? -3.0 -10.0 3
+    double? 3.0  -10.0 -3
+    double? -3.0 10.0  -3
+    double? 3.0  10.0  3.0
+    double? -3.0 -10.0 3.0
+    double? 3.0  -10.0 -3.0
+    double? -3.0 10.0  -3.0
+
+    decimal? 3.0M  10     3.0M
+    decimal? -3.0M -10    3.0M
+    decimal? 3.0M  -10    -3.0M
+    decimal? -3.0M 10     -3.0M
+    decimal? 3.0M  10.0M  3
+    decimal? -3.0M -10.0M 3
+    decimal? 3.0M  -10.0M -3
+    decimal? -3.0M 10.0M  -3
+    decimal? 3.0M  10.0M  3.0M
+    decimal? -3.0M -10.0M 3.0M
+    decimal? 3.0M  -10.0M -3.0M
+    decimal? -3.0M 10.0M  -3.0M
+
+    ;; Unexpectedly downconverts result to double, rather than BigDecimal
+    double? 3.0  10.0M  3.0
+    double? -3.0 -10.0M 3.0
+    double? 3.0  -10.0M -3.0
+    double? -3.0 10.0M  -3.0
+    double? 3.0  10.0   3.0M
+    double? -3.0 -10.0  3.0M
+    double? 3.0  -10.0  -3.0M
+    double? -3.0 10.0   -3.0M
+
+    ;; Anything with a ratio seems to convert to BigInt
+    p/big-int? 6N  3     1/2
+    p/big-int? 2N  3     4/3
+    p/big-int? 1N  37/2  15
+    p/big-int? -6N 3     -1/2
+    p/big-int? -2N 3     -4/3
+    p/big-int? -1N 37/2  -15
+    p/big-int? -6N -3    1/2
+    p/big-int? -2N -3    4/3
+    p/big-int? -1N -37/2 15
+    p/big-int? 6N  -3    -1/2
+    p/big-int? 2N  -3    -4/3
+    p/big-int? 1N  -37/2 -15
+
+    double? 0.0 1 ##Inf
+    double? 0.0 1 ##-Inf)
+
+  (is (thrown? Exception (quot 10 0)))
+  (is (thrown? Exception (quot ##Inf 1))) ; surprising since (/ ##Inf 1) = ##Inf
+  (is (thrown? Exception (quot ##-Inf 1))) ; surprising since (/ ##-Inf 1) = ##-Inf
+  (is (thrown? Exception (quot ##NaN 1)))
+  (is (thrown? Exception (quot 1 ##NaN)))
+  (is (thrown? Exception (quot ##NaN 1))))
+

--- a/test/clojure/core_test/rem.cljc
+++ b/test/clojure/core_test/rem.cljc
@@ -1,0 +1,83 @@
+(ns clojure.core-test.rem
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.portability :as p]))
+
+(deftest test-rem
+  (are [type-pred expected x y] (let [r (rem x y)]
+                                  (and (type-pred r)
+                                       (= expected r)))
+    int? 1  10  3
+    int? -1 -10 3
+    int? -1 -10 -3
+    int? 1  10  -3
+
+    p/big-int? 1N  10   3N
+    p/big-int? -1N -10  3N
+    p/big-int? -1N -10  -3N
+    p/big-int? 1N  10   -3N
+    p/big-int? 1N  10N  3
+    p/big-int? -1N -10N 3
+    p/big-int? -1N -10N -3
+    p/big-int? 1N  10N  -3
+    p/big-int? 1N  10N  3N
+    p/big-int? -1N -10N 3N
+    p/big-int? -1N -10N -3N
+    p/big-int? 1N  10N  -3N
+
+    double? 1.0  10    3.0
+    double? -1.0 -10   3.0
+    double? -1.0 -10   -3.0
+    double? 1.0  10    -3.0
+    double? 1.0  10.0  3
+    double? -1.0 -10.0 3
+    double? -1.0 -10.0 -3
+    double? 1.0  10.0  -3
+    double? 1.0  10.0  3.0
+    double? -1.0 -10.0 3.0
+    double? -1.0 -10.0 -3.0
+    double? 1.0  10.0  -3.0
+
+    decimal? 1.0M  10     3.0M
+    decimal? -1.0M -10    3.0M
+    decimal? -1.0M -10    -3.0M
+    decimal? 1.0M  10     -3.0M
+    decimal? 1.0M  10.0M  3
+    decimal? -1.0M -10.0M 3
+    decimal? -1.0M -10.0M -3
+    decimal? 1.0M  10.0M  -3
+    decimal? 1.0M  10.0M  3.0M
+    decimal? -1.0M -10.0M 3.0M
+    decimal? -1.0M -10.0M -3.0M
+    decimal? 1.0M  10.0M  -3.0M
+
+    ;; Unexpectedly downconverts result to double, rather than BigDecimal
+    double? 1.0  10.0M  3.0
+    double? -1.0 -10.0M 3.0
+    double? -1.0 -10.0M -3.0
+    double? 1.0  10.0M  -3.0
+    double? 1.0  10.0   3.0M
+    double? -1.0 -10.0  3.0M
+    double? -1.0 -10.0  -3.0M
+    double? 1.0  10.0   -3.0M
+
+    p/big-int? 0N   3     1/2
+    ratio?     1/3  3     4/3
+    ratio?     7/2  37/2  15
+    p/big-int? 0N   3     -1/2
+    ratio?     1/3  3     -4/3
+    ratio?     7/2  37/2  -15
+    p/big-int? 0N   -3    1/2
+    ratio?     -1/3 -3    4/3
+    ratio?     -7/2 -37/2 15
+    p/big-int? 0N   -3    -1/2
+    ratio?     -1/3 -3    -4/3
+    ratio?     -7/2 -37/2 -15)
+
+  (is (thrown? Exception (rem 10 0)))
+  (is (thrown? Exception (rem ##Inf 1))) ; surprising since (/ ##Inf 1) = ##Inf
+  (is (NaN? (rem 1 ##Inf)))
+  (is (thrown? Exception (rem ##-Inf 1))) ; surprising since (/ ##-Inf 1) = ##-Inf
+  (is (NaN? (rem 1 ##-Inf)))
+  (is (thrown? Exception (rem ##NaN 1)))
+  (is (thrown? Exception (rem 1 ##NaN)))
+  (is (thrown? Exception (rem ##NaN 1))))


### PR DESCRIPTION
Add tests for:

- `quot`
- `rem`
- `mod`

Also adds a file called `portability.cljc` in which we can add various portability functions.