### PR TITLE
Add tests for `numerator` and `denominator`

### DIFF
--- a/test/clojure/core_test/denominator.cljc
+++ b/test/clojure/core_test/denominator.cljc
@@ -1,0 +1,17 @@
+(ns clojure.core-test.denominator
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.portability :as p]))
+
+(p/when-var-exists 'clojure.core/denominator
+ (deftest test-denominator
+   (is (= 2 (denominator 1/2)))
+   (is (= 3 (denominator 2/3)))
+   (is (= 4 (denominator 3/4)))
+
+   (is (thrown? Exception (denominator 1)))
+   (is (thrown? Exception (denominator 1.0)))
+   (is (thrown? Exception (denominator 1N)))
+   (is (thrown? Exception (denominator 1.0M)))
+   (is (thrown? Exception (denominator ##Inf)))
+   (is (thrown? Exception (denominator ##NaN)))
+   (is (thrown? Exception (denominator nil)))))

--- a/test/clojure/core_test/numerator.cljc
+++ b/test/clojure/core_test/numerator.cljc
@@ -1,0 +1,17 @@
+(ns clojure.core-test.numerator
+  (:require [clojure.test :as t :refer [deftest testing is are]]
+            [clojure.core-test.portability :as p]))
+
+(p/when-var-exists 'clojure.core/numerator
+ (deftest test-numerator
+   (is (= 1 (numerator 1/2)))
+   (is (= 2 (numerator 2/3)))
+   (is (= 3 (numerator 3/4)))
+
+   (is (thrown? Exception (numerator 1)))
+   (is (thrown? Exception (numerator 1.0)))
+   (is (thrown? Exception (numerator 1N)))
+   (is (thrown? Exception (numerator 1.0M)))
+   (is (thrown? Exception (numerator ##Inf)))
+   (is (thrown? Exception (numerator ##NaN)))
+   (is (thrown? Exception (numerator nil)))))

--- a/test/clojure/core_test/portability.cljc
+++ b/test/clojure/core_test/portability.cljc
@@ -1,5 +1,13 @@
 (ns clojure.core-test.portability)
 
+(defmacro when-var-exists [var-sym & body]
+  `(let [s# ~var-sym
+         v# (resolve s#)]
+     (if v#
+       (do
+         ~@body)
+       (println "SKIP -" s#))))
+
 (defn big-int? [n]
   (and (integer? n)
        (not (int? n))))


### PR DESCRIPTION
1. Add portability macro `when-var-exists` in `portability.cljc`.
2. Add tests for `numerator`
3. Add tests for `denominator`
