### PR TITLE
Fix indentation of test files

### DIFF
--- a/test/clojure/core_test/integer_questionmark.cljc
+++ b/test/clojure/core_test/integer_questionmark.cljc
@@ -4,50 +4,50 @@
             [clojure.core-test.portability #?(:cljs :refer-macros :default :refer)  [when-var-exists]]))
 
 (when-var-exists clojure.core/integer?
-                 (deftest test-integer?
-                   (are [expected x] (= expected (integer? x))
-                     true  0
-                     true  1
-                     true  -1
-                     true  r/max-int
-                     true  r/min-int
-                     #?@(:cljs [true] :default [false]) 0.0
-                     #?@(:cljs [true] :default [false]) 1.0
-                     #?@(:cljs [true] :default [false]) -1.0
-                     false 0.1
-                     false 1.1
-                     false -1.1
-                     false r/max-double
-                     false r/min-double
-                     false ##Inf
-                     false ##-Inf
-                     false ##NaN
-                     true   0N
-                     true   1N
-                     true   -1N
-                     #?@(:cljs []
-                         :default
-                         [true  0/2                          ; perhaps surprising
-                          false 1/2
-                          false -1/2])
-                     #?@(:cljs [true] :default [false])  0.0M
-                     #?@(:cljs [true] :default [false])  1.0M
-                     #?@(:cljs [true] :default [false])  -1.0M
-                     false nil
-                     false true
-                     false false
-                     false "a string"
-                     false "0"
-                     false "1"
-                     false "-1"
-                     false {:a :map}
-                     false #{:a-set}
-                     false [:a :vector]
-                     false '(:a :list)
-                     false \0
-                     false \1
-                     false :a-keyword
-                     false :0
-                     false :1
-                     false :-1
-                     false 'a-sym)))
+  (deftest test-integer?
+    (are [expected x] (= expected (integer? x))
+      true  0
+      true  1
+      true  -1
+      true  r/max-int
+      true  r/min-int
+      #?@(:cljs [true] :default [false]) 0.0
+      #?@(:cljs [true] :default [false]) 1.0
+      #?@(:cljs [true] :default [false]) -1.0
+      false 0.1
+      false 1.1
+      false -1.1
+      false r/max-double
+      false r/min-double
+      false ##Inf
+      false ##-Inf
+      false ##NaN
+      true   0N
+      true   1N
+      true   -1N
+      #?@(:cljs []
+          :default
+          [true  0/2                          ; perhaps surprising
+           false 1/2
+           false -1/2])
+      #?@(:cljs [true] :default [false])  0.0M
+      #?@(:cljs [true] :default [false])  1.0M
+      #?@(:cljs [true] :default [false])  -1.0M
+      false nil
+      false true
+      false false
+      false "a string"
+      false "0"
+      false "1"
+      false "-1"
+      false {:a :map}
+      false #{:a-set}
+      false [:a :vector]
+      false '(:a :list)
+      false \0
+      false \1
+      false :a-keyword
+      false :0
+      false :1
+      false :-1
+      false 'a-sym)))

--- a/test/clojure/core_test/zero_questionmark.cljc
+++ b/test/clojure/core_test/zero_questionmark.cljc
@@ -4,36 +4,36 @@
             [clojure.core-test.portability #?(:cljs :refer-macros :default :refer) [when-var-exists]]))
 
 (when-var-exists clojure.core/zero?
-                 (deftest test-zero?
-                   (are [expected x] (= expected (zero? x))
-                     true  0
-                     false 1
-                     false -1
-                     false r/min-int
-                     false r/max-int
-                     true  0.0
-                     false 1.0
-                     false -1.0
-                     false r/min-double
-                     false r/max-double
-                     false ##Inf
-                     false ##-Inf
-                     false ##NaN
-                     true  0N
-                     false 1N
-                     false -1N
-                     #?@(:cljs []
-                         :default
-                         [true  0/2
-                          false 1/2
-                          false -1/2])
-                     true  0.0M
-                     false 1.0M
-                     false -1.0M)
+  (deftest test-zero?
+    (are [expected x] (= expected (zero? x))
+      true  0
+      false 1
+      false -1
+      false r/min-int
+      false r/max-int
+      true  0.0
+      false 1.0
+      false -1.0
+      false r/min-double
+      false r/max-double
+      false ##Inf
+      false ##-Inf
+      false ##NaN
+      true  0N
+      false 1N
+      false -1N
+      #?@(:cljs []
+          :default
+          [true  0/2
+           false 1/2
+           false -1/2])
+      true  0.0M
+      false 1.0M
+      false -1.0M)
 
-                   (is #?@(:cljs [(= false (zero? nil))]
-                           :default [(thrown? Exception (zero? nil))]))
-                   (is #?@(:cljs [(= false (zero? false))]
-                           :default [(thrown? Exception (zero? false))]))
-                   (is #?@(:cljs [(= false (zero? true))]
-                           :default [(thrown? Exception (zero? true))]))))
+    (is #?@(:cljs [(= false (zero? nil))]
+            :default [(thrown? Exception (zero? nil))]))
+    (is #?@(:cljs [(= false (zero? false))]
+            :default [(thrown? Exception (zero? false))]))
+    (is #?@(:cljs [(= false (zero? true))]
+            :default [(thrown? Exception (zero? true))]))))


### PR DESCRIPTION
Created a ~/.config/clojure-lsp/config.edn file with the following:

```edn
{:cljfmt {:extra-indents {#re "^with" [[:inner 0]]
                          #re "^def"  [[:inner 0]]
                          #re "^let"  [[:inner 0]]
                          #re "^box"  [[:inner 0]]
                          #re "^h-box"  [[:inner 0]]
                          #re "^v-box"  [[:inner 0]]
                          #re "^fn\\*"  [[:inner 0]]
                          #re "^when-"  [[:inner 0]]}}}
```

Now auto-formatting from me won't drive anyone crazy 😆