### PR TITLE
Add test for bound-fn

### DIFF
--- a/test/clojure/core_test/binding.cljc
+++ b/test/clojure/core_test/binding.cljc
@@ -49,7 +49,6 @@
     (binding [*x* :here]
       (t/is (= @f :here) "Delayed functions inherit there bindings when forced"))
     (t/is (= @f :here) "And value persists outside binding expression"))
-  (Thread/sleep 1)
   (let [f (future (test-fn))]
     (binding [*x* :now-here]
       (t/is (= @f :unset) "Thread context is separate from joining thread")))

--- a/test/clojure/core_test/bound_fn.cljc
+++ b/test/clojure/core_test/bound_fn.cljc
@@ -4,46 +4,48 @@
 
 (def ^:dynamic *x* :unset)
 
-(t/deftest test-bound-fn
-  ;; base-case
-  (let [f (bound-fn [] *x*)]
-    (t/is (= (f) :unset) "picks up dynamic vars")
-    (binding [*x* :set]
-      (t/is (= (f) :set) "And tracks their changes")))
+(when-var-exists clojure.core/bound-fn
+ (t/deftest test-bound-fn
+   (t/testing "base case"
+     (let [f (bound-fn [] *x*)]
+       (t/is (= (f) :unset) "picks up dynamic vars")
+       (binding [*x* :set]
+         (t/is (= (f) :set) "And tracks their changes"))))
 
-  ;; common cases
-  (binding [*x* :set]
-    (let [f (bound-fn [] *x*)]
-      (binding [*x* :set-again]
-        (t/is (= (f) :set) "bound-fn stores values"))))
+   (t/testing "Common cases"
+     (binding [*x* :set]
+       (let [f (bound-fn [] *x*)]
+         (binding [*x* :set-again]
+           (t/is (= (f) :set) "bound-fn stores values")))))
 
-  ;; infinite seqs
-  (binding [*x* (range)]
-    (let [f (bound-fn [] *x*)]
-      (binding [*x* (drop 50 (range))]
-        (t/is (= (range 10)
-                 (take 10 (f))
-                 (take 10 (f))) "infinite seqs work"))))
+   (t/testing "Infinite seqs"
+     (binding [*x* (range)]
+       (let [f (bound-fn [] *x*)]
+         (binding [*x* (drop 50 (range))]
+           (t/is (= (range 10)
+                    (take 10 (f))
+                    (take 10 (f))) "infinite seqs work")))))
 
-  ;; Nested cases
-  (binding [*x* :first!]
-    (let [f (bound-fn [] *x*)]
-      (binding [*x* :second!]
-        (let [f (bound-fn [] [(f) *x*])]
-          (t/is (= (f) [:first! :second!]) "Nested bound functions work as expected.")))))
-  (let [f (fn [] (binding [*x* :inside-f]
-                   (bound-fn [] *x*)))]
-    (binding [*x* :outside-f]
-      (t/is (= ((f)) :inside-f) "bound-fn as result preserves initial bindings")))
-    ;; Threading/future/delay cases
-  (let [f (bound-fn [] *x*)]
-    (let [fut (future (f))]
-      (binding [*x* :here]
-        (t/is (= @fut :unset) "bound-fn stays bound even in other thread"))))
-  (binding [*x* :caller]
-    (let [f (future
-              (binding [*x* :callee]
-                (future (bound-fn [] *x*))))]
-      (binding [*x* :derefer]
-        (let [derefed-f @f]
-          (t/is (= :callee (@derefed-f)) "Binding in futures preserved."))))))
+   (t/testing "Nested cases"
+     (binding [*x* :first!]
+       (let [f (bound-fn [] *x*)]
+         (binding [*x* :second!]
+           (let [f (bound-fn [] [(f) *x*])]
+             (t/is (= (f) [:first! :second!]) "Nested bound functions work as expected.")))))
+     (let [f (fn [] (binding [*x* :inside-f]
+                      (bound-fn [] *x*)))]
+       (binding [*x* :outside-f]
+         (t/is (= ((f)) :inside-f) "bound-fn as result preserves initial bindings"))))
+
+   (t/testing "Threaded/future cases"
+     (let [f (bound-fn [] *x*)]
+       (let [fut (future (f))]
+         (binding [*x* :here]
+           (t/is (= @fut :unset) "bound-fn stays bound even in other thread"))))
+     (binding [*x* :caller]
+       (let [f (future
+                 (binding [*x* :callee]
+                   (future (bound-fn [] *x*))))]
+         (binding [*x* :derefer]
+           (let [derefed-f @f]
+             (t/is (= :callee (@derefed-f)) "Binding in futures preserved."))))))))

--- a/test/clojure/core_test/bound_fn.cljc
+++ b/test/clojure/core_test/bound_fn.cljc
@@ -1,0 +1,49 @@
+(ns clojure.core-test.bound-fn
+  (:require [clojure.test :as t]
+            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer)  [when-var-exists]]))
+
+(def ^:dynamic *x* :unset)
+
+(t/deftest test-bound-fn
+  ;; base-case
+  (let [f (bound-fn [] *x*)]
+    (t/is (= (f) :unset) "picks up dynamic vars")
+    (binding [*x* :set]
+      (t/is (= (f) :set) "And tracks their changes")))
+
+  ;; common cases
+  (binding [*x* :set]
+    (let [f (bound-fn [] *x*)]
+      (binding [*x* :set-again]
+        (t/is (= (f) :set) "bound-fn stores values"))))
+
+  ;; infinite seqs
+  (binding [*x* (range)]
+    (let [f (bound-fn [] *x*)]
+      (binding [*x* (drop 50 (range))]
+        (t/is (= (range 10)
+                 (take 10 (f))
+                 (take 10 (f))) "infinite seqs work"))))
+
+  ;; Nested cases
+  (binding [*x* :first!]
+    (let [f (bound-fn [] *x*)]
+      (binding [*x* :second!]
+        (let [f (bound-fn [] [(f) *x*])]
+          (t/is (= (f) [:first! :second!]) "Nested bound functions work as expected.")))))
+  (let [f (fn [] (binding [*x* :inside-f]
+                   (bound-fn [] *x*)))]
+    (binding [*x* :outside-f]
+      (t/is (= ((f)) :inside-f) "bound-fn as result preserves initial bindings")))
+    ;; Threading/future/delay cases
+  (let [f (bound-fn [] *x*)]
+    (let [fut (future (f))]
+      (binding [*x* :here]
+        (t/is (= @fut :unset) "bound-fn stays bound even in other thread"))))
+  (binding [*x* :caller]
+    (let [f (future
+              (binding [*x* :callee]
+                (future (bound-fn [] *x*))))]
+      (binding [*x* :derefer]
+        (let [derefed-f @f]
+          (t/is (= :callee (@derefed-f)) "Binding in futures preserved."))))))


### PR DESCRIPTION
This adds tests for `bound-fn`. The helper `when-var-exists` seems not to work for macros. Do we have a solution for those or should I wrap the test in a reader macro for now? 