### PR TITLE
Prevent unreachable code from when-var-exists? macro

### DIFF
--- a/test/clojure/core_test/portability.cljc
+++ b/test/clojure/core_test/portability.cljc
@@ -5,10 +5,10 @@
         exists? (boolean (if cljs?
                            ((resolve 'cljs.analyzer.api/resolve) &env var-sym)
                            (resolve var-sym)))]
-    `(if ~exists?
-       (do
+    (if exists?
+      `(do
          ~@body)
-       (println "SKIP -" '~var-sym))))
+      `(println "SKIP -" '~var-sym))))
 
 (defn big-int? [n]
   (and (integer? n)


### PR DESCRIPTION
The `when-var-exists?` macro is implemented as:
```clojure
(defmacro when-var-exists [var-sym & body]
  (let [cljs? (some? (:ns &env))
        exists? (boolean (if cljs?
                           ((resolve 'cljs.analyzer.api/resolve) &env var-sym)
                           (resolve var-sym)))]
    `(if ~exists?
       (do
         ~@body)
       (println "SKIP -" '~var-sym))))
```

Given a test suite like the following:

```clojure
(ns clojure.core-test.intern
  (:require [clojure.test :as t :refer [deftest testing is are]]
            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer)  [when-var-exists]]))

(when-var-exists clojure.core/intern
  (deftest test-intern
    (is (some? intern) "This shouldn't run in cljs")))
```

It produces the following output:
```clojure
(ns clojure.core-test.intern
  (:require [clojure.test :as t :refer [deftest testing is are]]
            [clojure.core-test.portability #?(:cljs :refer-macros :default :refer)  [when-var-exists]]))

(if false
  (do
    (deftest test-intern
      (is (some? intern) "This shouldn't run in cljs")))
  (println "SKIP - " 'clojure.core/intern))
```

Which means the shadow-cljs compiler is still processing it and is
throwing a lot of undefined var warnings.

If the macro is changed minimally to:
```clojure
(defmacro when-var-exists [var-sym & body]
  (let [cljs? (some? (:ns &env))
        exists? (boolean (if cljs?
                           ((resolve 'cljs.analyzer.api/resolve) &env var-sym)
                           (resolve var-sym)))]
    (if exists?
      ~(do
         ~@body)
      ~(println "SKIP -" '~var-sym))))
```

Then it would output code like:

```clojure
(println "SKIP - " 'clojure.core/intern)
```

This should prevent the cljs compiler from having to deal with the code it can't run.