### PR TITLE
Fix conditional reads in `denominator`

### DIFF
--- a/test/clojure/core_test/denominator.cljc
+++ b/test/clojure/core_test/denominator.cljc
@@ -2,18 +2,16 @@
   (:require [clojure.test :as t :refer [deftest testing is are]]
             [clojure.core-test.portability #?(:cljs :refer-macros :default :refer)  [when-var-exists]]))
 
-#?(:cljs nil
-   :default
-   (when-var-exists clojure.core/denominator
-     (deftest test-denominator
-       (is (= 2 (denominator 1/2)))
-       (is (= 3 (denominator 2/3)))
-       (is (= 4 (denominator 3/4)))
+(when-var-exists clojure.core/denominator
+  (deftest test-denominator
+    (is (= 2 (denominator 1/2)))
+    (is (= 3 (denominator 2/3)))
+    (is (= 4 (denominator 3/4)))
 
-       (is (thrown? #?(:cljs :default :default Exception) (denominator 1)))
-       (is (thrown? #?(:cljs :default :default Exception) (denominator 1.0)))
-       (is (thrown? #?(:cljs :default :default Exception) (denominator 1N)))
-       (is (thrown? #?(:cljs :default :default Exception) (denominator 1.0M)))
-       (is (thrown? #?(:cljs :default :default Exception) (denominator ##Inf)))
-       (is (thrown? #?(:cljs :default :default Exception) (denominator ##NaN)))
-       (is (thrown? #?(:cljs :default :default Exception) (denominator nil))))))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator 1)))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator 1.0)))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator 1N)))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator 1.0M)))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator ##Inf)))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator ##NaN)))
+    (is (thrown? #?(:cljs :default :default Exception) (denominator nil)))))


### PR DESCRIPTION
`denominator.cljc` had a conditional read form wrapping the `when-var-exists` form, which made the tests disappear in CLJS testing, neither showing as "SKIP" nor appearing as tested. This removes the conditional reader form and just lets `when-var-exists` handle it.