### PR TITLE
Fix subs test

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -11,4 +11,5 @@
          :ns-regexp "-test"
          :autorun true
          :compiler-options {:warnings {:invalid-arithmetic false}}
-         :release {:autorun false}}}}
+         :release {:autorun false
+                   :compiler-options {:optimizations :simple}}}}}

--- a/test/clojure/core_test/subs.cljc
+++ b/test/clojure/core_test/subs.cljc
@@ -17,10 +17,7 @@
          (is (= "abcde" (subs "abcde" -1)))
          (is (= "abc" (subs "abcde" -1 3)))
          (is (= "" (subs "abcde" -1 -3)))
-         (try
-           (subs nil 1 2)
-           (catch :default err
-             (is (= (.-message err) "Cannot read properties of null (reading 'substring')"))))
+         (is (thrown? :default (subs nil 1 2)))
          (is (= "ab" (subs "abcde" nil 2)))
          (is (= "a" (subs "abcde" 1 nil)))]
         :default


### PR DESCRIPTION
Previously, when building a release version of the tests, shadow-cljs defaults to :advanced optimizations. For most apps, the default behavior is ideal and you get really well optimized code.

Code like `("abcde" nil 1 2)` gets inlined to `"abcde".substring(1,2)`, but in our tests `(subs nil 1 2)` would get inlined to `null.substring(1,2)`. Given the Google Closure compiler shadow-cljs uses, it recognizes that is invalid code and just outputs `null`. This results in code that is effectively `(thrown? nil)` which raises the error about receiving nil instead.

This sets the :optimizations to :simple in the release build. While it still produces decently optimized code, it doesn't factor out our intentionally invalid calls which is ideal for writing tests.