### PR TITLE
Disable elide-asserts in release builds

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -12,4 +12,5 @@
          :autorun true
          :compiler-options {:warnings {:invalid-arithmetic false}}
          :release {:autorun false
-                   :compiler-options {:optimizations :simple}}}}}
+                   :compiler-options {:optimizations :simple
+                                      :elide-asserts false}}}}}


### PR DESCRIPTION
Shadow-cljs defaults to eliding assert calls in release builds but not development builds. This makes behavior more consistent between dev and releases.

Also of note, the tests were compiled with elide-asserts false and optimizations advanced to see if we still need to use simple. The results were that subs failed again so for now optimizations should be simple and elide-asserts need to be false.